### PR TITLE
Build the high bit depth version of the HEVC encoder directly in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /tools && \
     cd /tools && \
     svn checkout https://hevc.hhi.fraunhofer.de/svn/svn_HEVCSoftware/tags/HM-16.18+SCM-8.7/ && \
     cd HM-16.18+SCM-8.7/build/linux && \
-    make
+    make release_highbitdepth
 
 # VMAF, FFMPEG
 RUN mkdir -p /tools && \

--- a/README.md
+++ b/README.md
@@ -47,24 +47,5 @@ Example: `./compare.py images/classA_8bit/`
 #### Notes from PINAR:
 If you want to exclude a codec, remove the <codecname>.py file from both `./encode` and `./decode` folders.
 
-If you are going to encode and decode images with bit depth greater than 10bpp, after building the container you have to enable RExt__HIGH_BIT_DEPTH_SUPPORT. Here's how:
-
-After you build and run the container, type the following commands:
-
-apt-get update
-
-apt-get install vim
-
-Y
-
-vi /tools/HM-16.18+SCM-8.7/source/Lib/TLibCommon/TypeDef.h
-
-
-In line 132 you have #define RExt__HIGH_BIT_DEPTH_SUPPORT set to 0. You need to change this to 1, save and quit (press i to switch to insert mode, when you finish changes press ESC to exit insert mode, then type :wq and hit ENTER. Then build HM again.
-
-Now you won't have problems.
-
-And that's all :) 
-
 #### To generate graphs:
 `./visualize.py ./metrics/*.json`

--- a/decode/hevc.py
+++ b/decode/hevc.py
@@ -10,7 +10,7 @@ height  = sys.argv[4]
 pix_fmt = sys.argv[5]
 depth   = sys.argv[6]
 
-hevc_bin = '/tools/HM-16.18+SCM-8.7/bin/TAppDecoderStatic'
+hevc_bin = '/tools/HM-16.18+SCM-8.7/bin/TAppDecoderHighBitDepthStatic'
 tmp_dec  = '/tmp/tmp.rgb'
 tmp_dec_yuv = '/tmp/tmp.yuv'
 

--- a/encode/hevc.py
+++ b/encode/hevc.py
@@ -12,7 +12,7 @@ height     = sys.argv[5]
 pix_fmt    = sys.argv[6]
 depth      = sys.argv[7]
 
-hevc_bin = '/tools/HM-16.18+SCM-8.7/bin/TAppEncoderStatic'
+hevc_bin = '/tools/HM-16.18+SCM-8.7/bin/TAppEncoderHighBitDepthStatic'
 if depth == '12' or depth == '16' or depth == '32' or pix_fmt == 'pgm':
     hevc_cfg = '/tools/HM-16.18+SCM-8.7/cfg/encoder_intra_main_rext.cfg'
 else:


### PR DESCRIPTION
It seems easier to proceed like this.